### PR TITLE
CHG: source string to if statement in case the file is accidentally deleted

### DIFF
--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -97,7 +97,7 @@ pub fn init_shell(config: Option<Config>, shell: Shell) -> Result<()> {
 
     std::fs::write(&shell_script_target, shell_script)?;
 
-    let source_string = format!("source {}", &shell_script_target);
+    let source_string = format!("if [ -f '{}' ]; then . '{}'; fi", &shell_script_target, &shell_script_target);
 
     let mut config = std::fs::read_to_string(&config_path)
         .with_context(|| format!("failed to read config path {}", config_path))?;
@@ -112,7 +112,7 @@ pub fn init_shell(config: Option<Config>, shell: Shell) -> Result<()> {
 pub fn remove_shell(shell: Shell) -> Result<()> {
     let shell_script_target = shell.get_shell_script_target()?;
     let config_path = shell.get_config_path()?;
-    let source_string = format!("source {}", &shell_script_target);
+    let source_string = format!("if [ -f '{}' ]; then . '{}'; fi", &shell_script_target, &shell_script_target);
     let mut config = std::fs::read_to_string(&config_path)
         .with_context(|| format!("failed to read config path {}", config_path))?;
 


### PR DESCRIPTION
Changes the source string to an if statement that first checks if the file exists before sourcing it.