### PR TITLE
ADD shell initialization without needing to explicitly specify (`cdwe init`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 # ⚡️cdwe (cd with env)
-A simple configurable cd wrapper that provides powerful utilities for customizing your envionment per directory. \
+A simple configurable cd wrapper that provides powerful utilities for customizing your environment per directory. \
 *(For **ZSH** / **BASH** / **FISH** Shells)*
 
 
@@ -37,7 +37,12 @@ cdwe init bash # bash shells
 cdwe init fish # fish shells
 ```
 
-3. **Reload your shell and start using!**
+3. **Reload your shell**
+```bash
+exec "$SHELL"
+```
+
+4. **Start using!**
 ```bash
 # check that env var gets set
 cdwe /Users/synoet/dev/projecta

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ cargo install cdwe
 
 2. **Init your shell**
 ```bash
+cdwe init
+# Or explicitly: 
 cdwe init zsh # zsh shells
 cdwe init bash # bash shells
 cdwe init fish # fish shells
@@ -257,7 +259,7 @@ similar directory structure for each user.
 ```bash
 cdwe-remove #removes the `source <output>` from your .zshrc/.bashrc/.fish
 
-zsh #reload your shell, use bash or fish if you use those.
+exec "$SHELL" #reload your shell, use bash or fish if you use those.
 ```
 
 2. Uninstall binary

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -16,7 +16,7 @@ pub enum Commands {
         #[arg(long = "new_dir", required = true)]
         new_dir: String,
     },
-    #[command(arg_required_else_help = true)]
+    #[command(arg_required_else_help = false)]
     Init {
         #[arg(value_name = "SHELL", required = false)]
         shell: Option<Shell>,

--- a/src/cmd/cmd.rs
+++ b/src/cmd/cmd.rs
@@ -18,15 +18,15 @@ pub enum Commands {
     },
     #[command(arg_required_else_help = true)]
     Init {
-        #[arg(value_name = "SHELL", required = true)]
+        #[arg(value_name = "SHELL", required = false)]
         shell: Option<Shell>,
     },
     Reload {
-        #[arg(value_name = "SHELL", required = true)]
+        #[arg(value_name = "SHELL", required = false)]
         shell: Option<Shell>,
     },
     Remove {
-        #[arg(value_name = "SHELL", required = true)]
+        #[arg(value_name = "SHELL", required = false)]
         shell: Option<Shell>,
     },
 }

--- a/src/cmd/shell.rs
+++ b/src/cmd/shell.rs
@@ -40,7 +40,7 @@ impl Shell {
     }
 
     pub fn from_string(s: &str) -> Result<Self> {
-        match s {
+        match s.to_lowercase().as_str() {
             "bash" => Ok(Shell::Bash),
             "fish" => Ok(Shell::Fish),
             "zsh" => Ok(Shell::Zsh),

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<()> {
     let cache_path = format!("{}/{}", &home, ".cdwe_cache.json");
 
     match matches.command {
-        cmd::Commands::Init { shell } => init_shell(None, shell.unwrap())?,
+        cmd::Commands::Init { shell } => init_shell(None, Some(shell.unwrap()))?,
         cmd::Commands::Run { old_dir, new_dir } => {
             let local_config_path = format!("{}/{}", new_dir, "cdwe.toml");
             let old_local_config_path = format!("{}/{}", old_dir, "cdwe.toml");
@@ -50,9 +50,9 @@ async fn main() -> Result<()> {
         }
         cmd::Commands::Reload { shell } => {
             let config: Config = Config::from_config_file(&config_path)?;
-            init_shell(Some(config), shell.unwrap())?;
+            init_shell(Some(config), Some(shell.unwrap()))?;
         }
-        cmd::Commands::Remove { shell } => remove_shell(shell.context("no shell passed")?)?,
+        cmd::Commands::Remove { shell } => remove_shell(Some(shell.context("no shell passed")?))?,
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<()> {
     let cache_path = format!("{}/{}", &home, ".cdwe_cache.json");
 
     match matches.command {
-        cmd::Commands::Init { shell } => init_shell(None, Some(shell.unwrap()))?,
+        cmd::Commands::Init { shell } => init_shell(None, shell)?,
         cmd::Commands::Run { old_dir, new_dir } => {
             let local_config_path = format!("{}/{}", new_dir, "cdwe.toml");
             let old_local_config_path = format!("{}/{}", old_dir, "cdwe.toml");
@@ -50,9 +50,9 @@ async fn main() -> Result<()> {
         }
         cmd::Commands::Reload { shell } => {
             let config: Config = Config::from_config_file(&config_path)?;
-            init_shell(Some(config), Some(shell.unwrap()))?;
+            init_shell(Some(config), shell)?;
         }
-        cmd::Commands::Remove { shell } => remove_shell(Some(shell.context("no shell passed")?))?,
+        cmd::Commands::Remove { shell } => remove_shell(shell)?,
     }
 
     Ok(())


### PR DESCRIPTION
Allows for the automatic detection of the current shell, so you can just start with `cdwe init` instead of specifying the shell as CL argument.